### PR TITLE
small typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 
 Flow Control allows the execution of code only under certain conditions. In Ruby, we used if statements, if/else statements, if/elsif/else statements, ternary operators, and case statements to control what code runs when. JavaScript has similar methods to control what blocks of code to execute: if statements, if/else statements, if/else if/else statements, ternary operators, and switch statements.
 
-You'll be writing your code in `js/flow-control.js`. Make sure to run the tests using `learn -b`.
+You'll be writing your code in `flow-control.js`. Make sure to run the tests using `learn -b`.
 
 ## If Statements
 


### PR DESCRIPTION
The readme said the file was `js/flow-control.js`, but it was actually `flow-control.js`.  I just chose to change the readme to match reality, but if you'd really rather it be `js/flow-control.js` go for it.